### PR TITLE
Support conversations API

### DIFF
--- a/main.go
+++ b/main.go
@@ -272,11 +272,11 @@ func handleFileShared(file *slack.FileSharedEvent) {
 
 func inspectHistory(ch slack.Channel) {
 	var err error
-	h := &slack.History{HasMore: true}
-	params := slack.NewHistoryParameters()
+	h := &slack.GetConversationHistoryResponse{HasMore: true}
+	params := &slack.GetConversationHistoryParameters{ChannelID: ch.ID}
 	for h.HasMore {
 		<-API_READY
-		h, err = RTM.GetChannelHistory(ch.ID, params)
+		h, err = RTM.GetConversationHistory(params)
 		if err != nil {
 			fatal("GetChannelHistory(%s, %v) failed: %v", ch.ID, params, err)
 		}

--- a/main.go
+++ b/main.go
@@ -116,7 +116,7 @@ func initTTL() {
 	}
 	info("Config: %v", cfgs)
 
-	channels, err := RTM.GetChannels(false)
+	channels, _, err := RTM.GetConversations(&slack.GetConversationsParameters{})
 	if err != nil {
 		fatal("GetChannles failed: %v", err)
 	}
@@ -309,7 +309,7 @@ func inspectFiles() {
 
 func inspectPast() {
 	<-API_READY
-	channels, err := RTM.GetChannels(true)
+	channels, _, err := RTM.GetConversations(&slack.GetConversationsParameters{})
 	if err != nil {
 		fatal("GetChannels() failed: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -118,7 +118,7 @@ func initTTL() {
 
 	channels, _, err := RTM.GetConversations(&slack.GetConversationsParameters{})
 	if err != nil {
-		fatal("GetChannles failed: %v", err)
+		fatal("GetChanneles failed: %v", err)
 	}
 	channelId := make(map[string]string)
 	for _, ch := range channels {


### PR DESCRIPTION
# Summary
Channels.* methods have been deprecated since June 10th, 2020 and will no longer be available from February 24th, 2021.
This PR is a patch to support the Conversations API, which is an alternative API to channels.* methods.

- https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
- https://github.com/slack-go/slack/blob/106d33d9f59459bb6111d67b0c04536e9482a796/conversation.go